### PR TITLE
Mobile-first M3 redesign with bottom navigation and touch targets

### DIFF
--- a/raikomix-youtube-dj_1.0/App.tsx
+++ b/raikomix-youtube-dj_1.0/App.tsx
@@ -6,8 +6,8 @@ import QueuePanel from './components/QueuePanel';
 import SearchPanel from './components/SearchPanel';
 import Toast, { ToastType } from './components/Toast';
 import MobilePortraitLayout, { MobilePanelTab } from './components/layouts/MobilePortraitLayout';
-import MobileLandscapeLayout from './components/layouts/MobileLandscapeLayout';
 import TabletLayout from './components/layouts/TabletLayout';
+import CompactMixer from './components/CompactMixer';
 import { PlayerState, DeckId, CrossfaderCurve, QueueItem, LibraryTrack, YouTubeSearchResult, TrackSourceType, EffectType } from './types';
 import {
   loadLibrary,
@@ -97,8 +97,8 @@ const App: React.FC = () => {
   const [mobileSheetTab, setMobileSheetTab] = useState<MobilePanelTab>('LIBRARY');
   const [mobileSheetExpanded, setMobileSheetExpanded] = useState(false);
   const [mobileDeckFocus, setMobileDeckFocus] = useState<'A' | 'B'>('A');
+  const [mobileNavTab, setMobileNavTab] = useState<'LIBRARY' | 'DECK_A' | 'DECK_B' | 'MIXER'>('DECK_A');
   const [tabletPanelTab, setTabletPanelTab] = useState<'LIBRARY' | 'QUEUE'>('LIBRARY');
-  const [effectsDrawerOpen, setEffectsDrawerOpen] = useState(false);
   const [effectsCollapsed, setEffectsCollapsed] = useState(false);
 
   const deckARef = useRef<DeckHandle>(null);
@@ -106,24 +106,30 @@ const App: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
 
   const isTablet = useMediaQuery('(min-width: 768px)');
-  const isLandscape = useMediaQuery('(min-width: 568px) and (max-width: 767px)');
-  const layoutMode: 'tablet' | 'landscape' | 'portrait' = isTablet ? 'tablet' : isLandscape ? 'landscape' : 'portrait';
+  const layoutMode: 'tablet' | 'portrait' = isTablet ? 'tablet' : 'portrait';
 
   useEffect(() => { saveLibrary(library); }, [library]);
 
   useEffect(() => {
     if (layoutMode === 'tablet') {
       setMobileSheetOpen(false);
-      setEffectsDrawerOpen(false);
     }
-    if (layoutMode === 'landscape') {
+    if (layoutMode === 'portrait') {
       setMobileSheetExpanded(false);
       if (mobileSheetTab === 'EFFECTS') setMobileSheetTab('LIBRARY');
     }
-    if (layoutMode === 'portrait') {
-      setEffectsDrawerOpen(false);
-    }
   }, [layoutMode, mobileSheetTab]);
+
+  useEffect(() => {
+    if (layoutMode !== 'portrait') return;
+    if (mobileNavTab === 'LIBRARY') {
+      setMobileSheetOpen(true);
+    } else {
+      setMobileSheetOpen(false);
+    }
+    if (mobileNavTab === 'DECK_A') setMobileDeckFocus('A');
+    if (mobileNavTab === 'DECK_B') setMobileDeckFocus('B');
+  }, [layoutMode, mobileNavTab]);
 
   const showNotification = (msg: string, type: ToastType = 'info') => setToast({ msg, type });
 
@@ -329,7 +335,7 @@ const App: React.FC = () => {
 
   const mixerPanel = (
     <Mixer
-      className="w-full max-w-[280px]"
+      className="w-full max-w-[360px]"
       crossfader={crossfader}
       onCrossfaderChange={setCrossfader}
       crossfaderCurve={xFaderCurve}
@@ -354,7 +360,7 @@ const App: React.FC = () => {
       <button
         type="button"
         onClick={() => setShowHelp(true)}
-        className="utility-button touch-target"
+        className="utility-button m3-touch touch-target"
         aria-label="Show shortcuts"
       >
         <span className="material-icons text-base">help_outline</span>
@@ -362,7 +368,7 @@ const App: React.FC = () => {
       <button
         type="button"
         onClick={toggleTheme}
-        className="utility-button touch-target"
+        className="utility-button m3-touch touch-target"
         aria-label="Toggle theme"
       >
         <span className="material-icons text-base">{theme === 'dark' ? 'light_mode' : 'dark_mode'}</span>
@@ -398,7 +404,29 @@ const App: React.FC = () => {
     />
   );
 
-  const landscapeSheetTab: 'LIBRARY' | 'QUEUE' = mobileSheetTab === 'QUEUE' ? 'QUEUE' : 'LIBRARY';
+  const handleMobileNavTabChange = (tab: 'LIBRARY' | 'DECK_A' | 'DECK_B' | 'MIXER') => {
+    setMobileNavTab(tab);
+    if (tab === 'DECK_A') setMobileDeckFocus('A');
+    if (tab === 'DECK_B') setMobileDeckFocus('B');
+    if (tab === 'LIBRARY') setMobileSheetOpen(true);
+    if (tab !== 'LIBRARY') setMobileSheetOpen(false);
+  };
+
+  const handleMobileSheetToggle = (open: boolean) => {
+    setMobileSheetOpen(open);
+    if (!open && mobileNavTab === 'LIBRARY') {
+      setMobileNavTab(mobileDeckFocus === 'B' ? 'DECK_B' : 'DECK_A');
+    }
+  };
+
+  const compactMixer = (
+    <CompactMixer
+      crossfader={crossfader}
+      onCrossfaderChange={setCrossfader}
+      masterVolume={masterVolume}
+      onMasterVolumeChange={setMasterVolume}
+    />
+  );
 
   return (
     <ErrorBoundary>
@@ -411,36 +439,19 @@ const App: React.FC = () => {
               mixer={mixerPanel}
               deckFocus={mobileDeckFocus}
               onDeckFocusChange={setMobileDeckFocus}
+              navTab={mobileNavTab}
+              onNavTabChange={handleMobileNavTabChange}
               sheetOpen={mobileSheetOpen}
               sheetTab={mobileSheetTab}
               onSheetTabChange={setMobileSheetTab}
-              onSheetToggle={setMobileSheetOpen}
+              onSheetToggle={handleMobileSheetToggle}
               sheetExpanded={mobileSheetExpanded}
               onSheetExpandedToggle={() => setMobileSheetExpanded(prev => !prev)}
               libraryPanel={libraryPanel}
               queuePanel={queuePanel}
               effectsPanel={effectsPanel}
               utilityBar={utilityBar}
-            />
-          )}
-
-          {layoutMode === 'landscape' && (
-            <MobileLandscapeLayout
-              deckA={deckA}
-              deckB={deckB}
-              mixer={mixerPanel}
-              sheetOpen={mobileSheetOpen}
-              sheetTab={landscapeSheetTab}
-              onSheetTabChange={(tab) => setMobileSheetTab(tab)}
-              onSheetToggle={setMobileSheetOpen}
-              sheetExpanded={mobileSheetExpanded}
-              onSheetExpandedToggle={() => setMobileSheetExpanded(prev => !prev)}
-              libraryPanel={libraryPanel}
-              queuePanel={queuePanel}
-              effectsPanel={effectsPanel}
-              effectsOpen={effectsDrawerOpen}
-              onEffectsToggle={setEffectsDrawerOpen}
-              utilityBar={utilityBar}
+              compactMixer={compactMixer}
             />
           )}
 

--- a/raikomix-youtube-dj_1.0/components/CompactMixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/CompactMixer.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+interface CompactMixerProps {
+  crossfader: number;
+  onCrossfaderChange: (val: number) => void;
+  masterVolume: number;
+  onMasterVolumeChange: (val: number) => void;
+}
+
+const CompactMixer: React.FC<CompactMixerProps> = ({
+  crossfader,
+  onCrossfaderChange,
+  masterVolume,
+  onMasterVolumeChange
+}) => {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="m3-section-title">Quick Mix</p>
+          <p className="text-sm text-white/70">Crossfader + Master</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onCrossfaderChange(0)}
+          className="utility-button m3-touch touch-target"
+          aria-label="Center crossfader"
+        >
+          <span className="material-icons text-base">center_focus_strong</span>
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs uppercase tracking-[0.2em] text-white/40">
+          <span>Deck A</span>
+          <span>Deck B</span>
+        </div>
+        <input
+          type="range"
+          min="-1"
+          max="1"
+          step="0.001"
+          value={crossfader}
+          onChange={(e) => onCrossfaderChange(parseFloat(e.target.value))}
+          className="w-full h-12 cursor-pointer"
+          aria-label="Crossfader"
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-semibold">Master</span>
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          value={masterVolume}
+          onChange={(e) => onMasterVolumeChange(parseFloat(e.target.value))}
+          onDoubleClick={() => onMasterVolumeChange(0.8)}
+          className="flex-1 h-12 cursor-pointer"
+          aria-label="Master volume"
+        />
+        <span className="text-sm font-mono text-white/70">{Math.round(masterVolume * 100)}%</span>
+      </div>
+    </div>
+  );
+};
+
+export default CompactMixer;

--- a/raikomix-youtube-dj_1.0/components/Deck.tsx
+++ b/raikomix-youtube-dj_1.0/components/Deck.tsx
@@ -729,7 +729,7 @@ const effectNodesRef = useRef<{
   };
 
   return (
-    <div className="m3-card bg-[#1D1B20] border-white/5 flex flex-col gap-4 shadow-2xl transition-all hover:border-[#D0BCFF]/20 relative overflow-hidden min-w-[420px]">
+    <div className="m3-card bg-[#1D1B20] border-white/5 flex flex-col gap-4 shadow-2xl transition-all hover:border-[#D0BCFF]/20 relative overflow-hidden w-full min-w-0">
       <div className="absolute top-0 left-0 w-px h-px opacity-0 pointer-events-none overflow-hidden">
         <div id={containerId} />
       </div>
@@ -744,10 +744,10 @@ const effectNodesRef = useRef<{
               <div className="text-4xl font-black" style={{ color }}>{id}</div>
             </div>
             <div className="text-right min-w-0 flex-1 overflow-hidden">
-              <MarqueeText text={state.title || 'Deck Ready'} className="text-sm font-bold text-white uppercase tracking-tight" />
+              <MarqueeText text={state.title || 'Deck Ready'} className="text-base font-bold text-white uppercase tracking-tight" />
               <MarqueeText 
                 text={state.author || (state.sourceType === 'local' ? 'Local Media' : 'Insert Media')} 
-                className="text-[10px] text-gray-500 font-bold uppercase tracking-widest opacity-80" 
+                className="text-sm text-gray-500 font-bold uppercase tracking-widest opacity-80" 
               />
             </div>
           </div>
@@ -758,18 +758,18 @@ const effectNodesRef = useRef<{
                 <div className={`text-3xl font-black mono ${isScanning ? 'animate-pulse text-gray-400' : ''}`} style={!isScanning ? { color } : {}}>
                   {(state.bpm * state.playbackRate).toFixed(1)}
                 </div>
-                <div className="text-[10px] text-gray-500 font-black uppercase">BPM</div>
+                <div className="text-xs text-gray-500 font-black uppercase">BPM</div>
               </div>
-              <div className="text-[10px] text-gray-600 font-black uppercase tracking-widest">Key: <span className="text-white/80">{state.musicalKey}</span></div>
+              <div className="text-xs text-gray-600 font-black uppercase tracking-widest">Key: <span className="text-white/80">{state.musicalKey}</span></div>
             </div>
-            <button onClick={handleTap} className="px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl text-[10px] font-black uppercase tracking-widest text-gray-400 hover:text-white">TAP</button>
+            <button onClick={handleTap} className="px-5 py-3 bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl text-sm font-black uppercase tracking-widest text-gray-200 hover:text-white m3-touch touch-target">TAP</button>
           </div>
 
           <div className="flex items-center justify-center py-1">
             <button
               onClick={togglePlay}
               disabled={!state.isReady}
-              className={`w-20 h-20 rounded-full bg-black border-[3px] flex items-center justify-center transition-all ${state.playing ? 'border-[#D0BCFF] shadow-[0_0_30px_rgba(208,188,255,0.2)]' : 'border-white/10'}`}
+              className={`w-20 h-20 rounded-full bg-black border-[3px] flex items-center justify-center transition-all m3-touch touch-target ${state.playing ? 'border-[#D0BCFF] shadow-[0_0_30px_rgba(208,188,255,0.2)]' : 'border-white/10'}`}
             >
               <span className="material-icons text-4xl text-white">{state.playing ? 'pause' : 'play_arrow'}</span>
             </button>
@@ -783,12 +783,12 @@ const effectNodesRef = useRef<{
           />
 
           <div className="space-y-1">
-            <div className="flex justify-between text-[9px] font-black uppercase text-gray-600 px-1">
+            <div className="flex justify-between text-xs font-black uppercase text-gray-600 px-1">
               <span>Timeline</span>
             <button
                 type="button"
                 onClick={() => setShowRemaining(prev => !prev)}
-                className="mono text-gray-400 hover:text-white transition-colors"
+                className="mono text-gray-300 hover:text-white transition-colors text-sm"
                 title="Toggle time display"
               >
                 {showRemaining
@@ -797,7 +797,7 @@ const effectNodesRef = useRef<{
               </button>
             </div>
             <div 
-              className="h-6 bg-black/50 rounded-lg relative cursor-pointer overflow-hidden border border-white/10"
+              className="h-10 bg-black/50 rounded-lg relative cursor-pointer overflow-hidden border border-white/10 touch-target"
               onClick={(e) => {
                 const rect = e.currentTarget.getBoundingClientRect();
                 const pct = (e.clientX - rect.left) / rect.width;
@@ -818,7 +818,7 @@ const effectNodesRef = useRef<{
         {/* Improved Pitch / Tempo Fader */}
         <div 
           ref={tempoContainerRef}
-          className="w-12 bg-black/20 rounded-xl border border-white/5 flex flex-col items-center py-4 gap-2 relative group select-none transition-all hover:border-white/20 active:border-[#D0BCFF]/30"
+          className="w-16 bg-black/20 rounded-xl border border-white/5 flex flex-col items-center py-4 gap-2 relative group select-none transition-all hover:border-white/20 active:border-[#D0BCFF]/30 m3-touch"
           onDoubleClick={() => updatePlaybackRate(1.0)}
       onPointerDown={handleTempoPointerDown}
           onPointerMove={handleTempoPointerMove}
@@ -831,7 +831,7 @@ const effectNodesRef = useRef<{
           }}
           title="Click/Drag to Pitch • Scroll for Fine-Tune • Double-click to Reset"
         >
-           <div className="text-[8px] font-black text-gray-500 uppercase tracking-tighter vertical-text h-10 mb-2">Tempo</div>
+           <div className="text-xs font-black text-gray-500 uppercase tracking-tighter vertical-text h-12 mb-2">Tempo</div>
            
            <div className="flex-1 w-full flex justify-center relative py-2">
               <div className="absolute inset-y-2 left-2 flex flex-col justify-between items-center pointer-events-none opacity-20">
@@ -840,15 +840,15 @@ const effectNodesRef = useRef<{
                 ))}
               </div>
 
-              <div className="h-full w-8 relative flex items-center justify-center cursor-ns-resize">
+              <div className="h-full w-10 relative flex items-center justify-center cursor-ns-resize">
                 <div
-                  className="absolute w-10 h-10 bg-[#323038] rounded-md border-2 border-white/20 shadow-[0_8px_16px_rgba(0,0,0,0.6)] flex items-center justify-center transition-all duration-75 pointer-events-none z-10"
+                  className="absolute w-12 h-12 bg-[#323038] rounded-md border-2 border-white/20 shadow-[0_8px_16px_rgba(0,0,0,0.6)] flex items-center justify-center transition-all duration-75 pointer-events-none z-10"
                   style={{
                     top: `${(1.5 - state.playbackRate) * 100}%`,
                     transform: 'translateY(-50%)'
                   }}
                 >
-                  <div className="w-6 h-[2px] bg-[#D0BCFF] shadow-[0_0_8px_#D0BCFF]" />
+                  <div className="w-7 h-[2px] bg-[#D0BCFF] shadow-[0_0_8px_#D0BCFF]" />
                 </div>
 
                 <input
@@ -865,7 +865,7 @@ const effectNodesRef = useRef<{
            </div>
 
            <div className="flex flex-col items-center gap-0.5 pb-2">
-             <div className={`text-[9px] font-black mono transition-all ${Math.abs(state.playbackRate - 1.0) < 0.001 ? 'text-[#D0BCFF] scale-110' : 'text-gray-500'}`}>
+             <div className={`text-xs font-black mono transition-all ${Math.abs(state.playbackRate - 1.0) < 0.001 ? 'text-[#D0BCFF] scale-110' : 'text-gray-500'}`}>
                 {((state.playbackRate - 1.0) * 100).toFixed(2)}%
              </div>
              <div className={`w-1.5 h-1.5 rounded-full transition-all ${Math.abs(state.playbackRate - 1.0) < 0.001 ? 'bg-[#D0BCFF] shadow-[0_0_8px_#D0BCFF]' : 'bg-transparent'}`} />
@@ -873,34 +873,39 @@ const effectNodesRef = useRef<{
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 mt-2">
-        <div className="bg-black/20 p-2 rounded-xl border border-white/5 space-y-2">
-          <div className="flex justify-between items-center px-1">
-             <div className="text-[9px] text-gray-500 font-black uppercase tracking-widest">Hot Cues</div>
-             <div className="text-[7px] text-gray-700 font-black uppercase">Shift + Click to Clear</div>
-          </div>
-          <div className="grid grid-cols-4 gap-1">
-            {[0, 1, 2, 3].map((i) => (
-              <button 
-                key={i} 
-                onClick={(e) => handleHotCue(i, e.shiftKey)} 
-                className={`h-8 rounded-lg font-black text-[10px] border transition-all ${state.hotCues[i] !== null ? 'text-black' : 'border-white/5 text-gray-700 hover:border-white/20'}`} 
-                style={state.hotCues[i] !== null ? { backgroundColor: CUE_COLORS[i], borderColor: CUE_COLORS[i], boxShadow: `0 0 10px ${CUE_COLORS[i]}44` } : {}}
-              >
-                {i + 1}
-              </button>
-            ))}
+      <details className="collapsible-panel">
+        <summary>Performance Controls</summary>
+        <div className="collapsible-content">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-black/20 p-3 rounded-xl border border-white/5 space-y-3">
+              <div className="flex justify-between items-center px-1">
+                 <div className="text-xs text-gray-400 font-black uppercase tracking-widest">Hot Cues</div>
+                 <div className="text-[11px] text-gray-600 font-black uppercase">Shift + Tap to Clear</div>
+              </div>
+              <div className="grid grid-cols-4 gap-2">
+                {[0, 1, 2, 3].map((i) => (
+                  <button 
+                    key={i} 
+                    onClick={(e) => handleHotCue(i, e.shiftKey)} 
+                    className={`h-12 rounded-lg font-black text-sm border transition-all m3-touch touch-target ${state.hotCues[i] !== null ? 'text-black' : 'border-white/5 text-gray-200 hover:border-white/20'}`} 
+                    style={state.hotCues[i] !== null ? { backgroundColor: CUE_COLORS[i], borderColor: CUE_COLORS[i], boxShadow: `0 0 10px ${CUE_COLORS[i]}44` } : {}}
+                  >
+                    {i + 1}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="bg-black/20 p-3 rounded-xl border border-white/5 space-y-3">
+              <div className="text-xs text-gray-400 font-black uppercase tracking-widest px-1">Loops</div>
+              <div className="grid grid-cols-4 gap-2">
+                {[2, 4, 8, 16].map((b) => (
+                  <button key={b} onClick={() => handleToggleLoop(b)} className={`h-12 rounded-lg text-sm font-black border transition-all m3-touch touch-target ${state.loopActive && Math.abs((state.loopEnd - state.loopStart) - b * (60 / state.bpm)) < 0.1 ? 'bg-green-500 text-black border-green-500 shadow-[0_0_10px_rgba(34,197,94,0.4)]' : 'border-white/5 text-gray-200 hover:text-white hover:border-white/20'}`}>{b}</button>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
-        <div className="bg-black/20 p-2 rounded-xl border border-white/5 space-y-2">
-          <div className="text-[9px] text-gray-500 font-black uppercase tracking-widest px-1">Loops</div>
-          <div className="grid grid-cols-4 gap-1">
-            {[2, 4, 8, 16].map((b) => (
-              <button key={b} onClick={() => handleToggleLoop(b)} className={`h-7 rounded-lg text-[10px] font-black border transition-all ${state.loopActive && Math.abs((state.loopEnd - state.loopStart) - b * (60 / state.bpm)) < 0.1 ? 'bg-green-500 text-black border-green-500 shadow-[0_0_10px_rgba(34,197,94,0.4)]' : 'border-white/5 text-gray-500 hover:text-white hover:border-white/20'}`}>{b}</button>
-            ))}
-          </div>
-        </div>
-      </div>
+      </details>
 
       {isLoading && (
         <div className="absolute inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">

--- a/raikomix-youtube-dj_1.0/components/EffectsPanel.tsx
+++ b/raikomix-youtube-dj_1.0/components/EffectsPanel.tsx
@@ -60,8 +60,8 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({
     <div className="bg-black/40 p-4 rounded-xl border border-white/5 relative z-10 space-y-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <p className="text-[10px] font-black text-gray-500 uppercase tracking-[0.3em]">FX Engine</p>
-          <p className="text-[11px] font-semibold text-white/80">
+          <p className="text-xs font-black text-gray-500 uppercase tracking-[0.3em]">FX Engine</p>
+          <p className="text-sm font-semibold text-white/80">
             {mixedEffect ? 'Mixed effects' : activeEffect ? activeEffect : 'No effect'}
           </p>
         </div>
@@ -70,7 +70,7 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({
             <button
               key={option}
               onClick={() => onTargetChange(option)}
-              className={`px-3 py-1 rounded-full text-[9px] font-black uppercase tracking-widest transition ${
+              className={`px-3 py-2 rounded-full text-xs font-black uppercase tracking-widest transition m3-touch touch-target ${
                 target === option ? 'text-black' : 'text-gray-500'
               }`}
               style={target === option ? { backgroundColor: color } : undefined}
@@ -81,12 +81,12 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({
         </div>
       </div>
       
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {effects.map((fx) => (
           <button
             key={fx.label}
             onClick={() => onEffectToggle(fx.value)}
-            className={`py-2 rounded-lg text-[10px] font-black transition-all border uppercase tracking-tight ${
+            className={`py-3 rounded-lg text-sm font-black transition-all border uppercase tracking-tight m3-touch touch-target ${
               activeEffect === fx.value
                 ? 'bg-white/15 border-white/30 text-white'
                 : 'bg-white/5 border-white/10 text-gray-500 hover:bg-white/10 hover:text-white/50'
@@ -101,10 +101,10 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({
       <div className="space-y-3 border-t border-white/5 pt-4">
         <div className="flex justify-between items-center px-1">
           <div>
-            <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest">Intensity</span>
-            {mixedIntensity && <span className="ml-2 text-[8px] text-white/40 uppercase">Mixed</span>}
+            <span className="text-xs font-black text-gray-500 uppercase tracking-widest">Intensity</span>
+            {mixedIntensity && <span className="ml-2 text-[10px] text-white/40 uppercase">Mixed</span>}
           </div>
-           <span className="text-[9px] font-mono text-white/50">{Math.round(effectIntensity * 100)}%</span>
+           <span className="text-xs font-mono text-white/50">{Math.round(effectIntensity * 100)}%</span>
         </div>
         <div className={`bg-black/20 p-2 rounded-full border border-white/5 ${!activeEffect ? 'opacity-40' : ''}`}>
           <input
@@ -118,7 +118,7 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({
               onIntensityChange(0.5);
               showResetToast('FX INTENSITY');
             }}
-            className="w-full accent-white h-2 cursor-pointer"
+            className="w-full accent-white h-12 cursor-pointer"
             style={{ accentColor: color }}
             title="Double-click to reset (50%)"
             disabled={!activeEffect}
@@ -127,10 +127,10 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({
 
         <div className="flex justify-between items-center px-1">
           <div>
-            <span className="text-[9px] font-black text-gray-500 uppercase tracking-widest">Wet / Dry</span>
-            {mixedAmount && <span className="ml-2 text-[8px] text-white/40 uppercase">Mixed</span>}
+            <span className="text-xs font-black text-gray-500 uppercase tracking-widest">Wet / Dry</span>
+            {mixedAmount && <span className="ml-2 text-[10px] text-white/40 uppercase">Mixed</span>}
           </div>
-          <span className="text-[9px] font-mono text-white/50">{Math.round(effectAmount * 100)}%</span>
+          <span className="text-xs font-mono text-white/50">{Math.round(effectAmount * 100)}%</span>
         </div>
         <div className={`bg-black/20 p-2 rounded-full border border-white/5 ${!activeEffect ? 'opacity-40' : ''}`}>
           <input
@@ -144,14 +144,14 @@ const EffectsPanel: React.FC<EffectsPanelProps> = ({
               onAmountChange(0.5);
               showResetToast('FX WET/DRY');
             }}
-            className="w-full accent-white h-2 cursor-pointer"
+            className="w-full accent-white h-12 cursor-pointer"
             style={{ accentColor: color }}
             title="Double-click to reset (50%)"
             disabled={!activeEffect}
           />
         </div>
            {showStreamingNotice && (
-          <p className="text-[9px] text-white/40 uppercase tracking-widest px-1">
+          <p className="text-xs text-white/40 uppercase tracking-widest px-1">
             Streaming FX unavailable
           </p>
         )}

--- a/raikomix-youtube-dj_1.0/components/Mixer.tsx
+++ b/raikomix-youtube-dj_1.0/components/Mixer.tsx
@@ -37,8 +37,8 @@ const Knob: React.FC<{
   const startVal = useRef(0);
   const activePointerId = useRef<number | null>(null);
   const knobRef = useRef<HTMLDivElement>(null);
-  const knobSize = size === 'sm' ? 'w-9 h-9' : 'w-11 h-11';
-  const innerSize = size === 'sm' ? 'w-5 h-5' : 'w-6 h-6';
+  const knobSize = size === 'sm' ? 'w-12 h-12' : 'w-14 h-14';
+  const innerSize = size === 'sm' ? 'w-7 h-7' : 'w-8 h-8';
 
  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -87,7 +87,7 @@ const Knob: React.FC<{
     <div className="flex flex-col items-center gap-0 group select-none">
       <div 
         ref={knobRef}
-        className={`relative ${knobSize} flex items-center justify-center cursor-ns-resize transition-transform duration-150 touch-none ${isDragging ? 'scale-110' : ''}`}
+        className={`relative ${knobSize} flex items-center justify-center cursor-ns-resize transition-transform duration-150 touch-none m3-touch touch-target ${isDragging ? 'scale-110' : ''}`}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
@@ -114,7 +114,7 @@ const Knob: React.FC<{
           <div className="w-0.5 h-2.5 bg-white/60 absolute top-0.5 rounded-full" />
         </div>
       </div>
-      <span className={`text-[6px] font-black uppercase tracking-tighter transition-colors pointer-events-none ${isDragging ? 'text-white' : 'text-gray-500 group-hover:text-white/60'}`}>{label}</span>
+      <span className={`text-[10px] font-black uppercase tracking-tighter transition-colors pointer-events-none ${isDragging ? 'text-white' : 'text-gray-400 group-hover:text-white/60'}`}>{label}</span>
     </div>
   );
 };
@@ -125,7 +125,7 @@ const Fader: React.FC<{
   onChange: (val: number) => void,
   color: string,
   height?: string
-}> = ({ label, value, onChange, color, height = 'h-28' }) => {
+}> = ({ label, value, onChange, color, height = 'h-32' }) => {
   const faderRef = useRef<HTMLDivElement>(null);
   const activePointerId = useRef<number | null>(null);
 
@@ -167,10 +167,10 @@ const Fader: React.FC<{
   };
 
   return (
-    <div className="flex flex-col items-center gap-1.5 w-full group relative">
+    <div className="flex flex-col items-center gap-2 w-full group relative">
        <div 
          ref={faderRef}
-            className={`${height} w-6 bg-black/40 rounded-lg relative flex items-end p-0.5 border border-white/5 overflow-hidden cursor-ns-resize shadow-inner touch-none`}
+            className={`${height} w-12 bg-black/40 rounded-lg relative flex items-end p-1 border border-white/5 overflow-hidden cursor-ns-resize shadow-inner touch-none m3-touch touch-target`}
        >
           <div 
             className="w-full rounded transition-all duration-75" 
@@ -192,7 +192,7 @@ const Fader: React.FC<{
              onPointerCancel={handlePointerUp}
           />
        </div>
-       <label className="text-[7px] font-black uppercase tracking-widest" style={{ color: `${color}99` }}>{label}</label>
+       <label className="text-[10px] font-black uppercase tracking-widest" style={{ color: `${color}99` }}>{label}</label>
     </div>
   );
 };
@@ -232,7 +232,7 @@ const Mixer: React.FC<MixerProps> = ({
     if (!rect) return;
     const rootFont = parseFloat(getComputedStyle(document.documentElement).fontSize || '16');
     const padding = rootFont;
-    const handleWidth = rootFont * 5;
+    const handleWidth = rootFont * 6;
     const usable = Math.max(1, rect.width - padding * 2 - handleWidth);
     const x = Math.min(Math.max(clientX - rect.left - padding - handleWidth / 2, 0), usable);
     const t = x / usable;
@@ -258,14 +258,14 @@ const Mixer: React.FC<MixerProps> = ({
   };
 
   return (
-    <div className={`m3-card h-full flex flex-col bg-[#1D1B20] shadow-2xl border-white/5 w-[280px] shrink-0 p-2 select-none ${className ?? ''}`} role="region" aria-label="Mixer Controls">
-      <div className="flex flex-col items-center gap-0 border-b border-white/5 pb-1 mb-2">
-        <h2 className="text-[8px] font-black uppercase tracking-[0.4em] text-[#D0BCFF]">Mixing Console</h2>
+    <div className={`m3-card h-full flex flex-col bg-[#1D1B20] shadow-2xl border-white/5 w-full max-w-[360px] md:w-[280px] shrink-0 p-3 select-none ${className ?? ''}`} role="region" aria-label="Mixer Controls">
+      <div className="flex flex-col items-center gap-0 border-b border-white/5 pb-2 mb-2">
+        <h2 className="text-xs font-black uppercase tracking-[0.3em] text-[#D0BCFF]">Mixing Console</h2>
       </div>
 
       <div className="flex-1 flex justify-between gap-1 overflow-hidden">
         {/* Channel A Section */}
-        <div className="flex flex-col items-center gap-2 bg-black/10 p-1.5 rounded-xl flex-1 border border-white/5">
+        <div className="flex flex-col items-center gap-3 bg-black/10 p-2 rounded-xl flex-1 border border-white/5">
           <div className="flex flex-col items-center gap-1.5 w-full">
             <Knob label="Trim" value={1} onChange={() => {}} color="#D0BCFF" size="sm" defaultValue={1} />
             <div className="w-full h-px bg-white/5" />
@@ -279,7 +279,7 @@ const Mixer: React.FC<MixerProps> = ({
 
           <button 
             onClick={() => setCueA(!cueA)}
-            className={`w-10 h-5 rounded-md text-[7px] font-black uppercase tracking-tighter transition-all border ${cueA ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-500'}`}
+            className={`w-12 h-12 rounded-xl text-xs font-black uppercase tracking-tighter transition-all border m3-touch touch-target ${cueA ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-200'}`}
           >
             Cue
           </button>
@@ -288,7 +288,7 @@ const Mixer: React.FC<MixerProps> = ({
         </div>
 
         {/* Master Section */}
-        <div className="flex flex-col items-center gap-2 py-2 px-0.5 w-10 bg-black/30 rounded-xl border border-white/5 mx-0.5">
+        <div className="flex flex-col items-center gap-2 py-2 px-1 w-12 bg-black/30 rounded-xl border border-white/5 mx-0.5">
            <div className="flex flex-col gap-0.5 items-center flex-1 py-1">
              {[...Array(20)].reverse().map((_, i) => {
                const isActive = (deckAPlaying || deckBPlaying) && (Math.random() > (i / 20));
@@ -302,11 +302,11 @@ const Mixer: React.FC<MixerProps> = ({
              })}
            </div>
            
-           <Fader label="MST" value={masterVolume} onChange={onMasterVolumeChange} color="#FFFFFF" height="h-20" />
+           <Fader label="MST" value={masterVolume} onChange={onMasterVolumeChange} color="#FFFFFF" height="h-24" />
         </div>
 
         {/* Channel B Section */}
-        <div className="flex flex-col items-center gap-2 bg-black/10 p-1.5 rounded-xl flex-1 border border-white/5">
+        <div className="flex flex-col items-center gap-3 bg-black/10 p-2 rounded-xl flex-1 border border-white/5">
           <div className="flex flex-col items-center gap-1.5 w-full">
             <Knob label="Trim" value={1} onChange={() => {}} color="#F2B8B5" size="sm" defaultValue={1} />
             <div className="w-full h-px bg-white/5" />
@@ -320,7 +320,7 @@ const Mixer: React.FC<MixerProps> = ({
 
           <button 
             onClick={() => setCueB(!cueB)}
-            className={`w-10 h-5 rounded-md text-[7px] font-black uppercase tracking-tighter transition-all border ${cueB ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-500'}`}
+            className={`w-12 h-12 rounded-xl text-xs font-black uppercase tracking-tighter transition-all border m3-touch touch-target ${cueB ? 'bg-orange-500 border-orange-400 text-white shadow-[0_0_8px_rgba(249,115,22,0.4)]' : 'bg-black/40 border-white/5 text-gray-200'}`}
           >
             Cue
           </button>
@@ -331,12 +331,12 @@ const Mixer: React.FC<MixerProps> = ({
 
       {/* Crossfader Section - Enhanced visual design */}
       <div className="mt-4 space-y-2 pt-2 border-t border-white/5 relative">
-        <div className="flex justify-between gap-1 p-0.5 bg-black/30 rounded-lg mb-1">
+        <div className="flex justify-between gap-1 p-1 bg-black/30 rounded-lg mb-1">
           {['SMOOTH', 'CUT', 'DIP'].map(curve => (
             <button 
               key={curve} 
               onClick={() => onCurveChange(curve as CrossfaderCurve)} 
-              className={`flex-1 py-1 text-[6px] font-black rounded-md transition-all ${crossfaderCurve === curve ? 'bg-[#D0BCFF] text-black shadow-lg' : 'text-gray-600 hover:text-gray-300'}`}
+              className={`flex-1 py-2 text-[10px] font-black rounded-md transition-all m3-touch touch-target ${crossfaderCurve === curve ? 'bg-[#D0BCFF] text-black shadow-lg' : 'text-gray-200 hover:text-white'}`}
             >
               {curve}
             </button>
@@ -360,9 +360,9 @@ const Mixer: React.FC<MixerProps> = ({
 
            {/* Professional Aluminum-style Crossfader Handle */}
            <div 
-             className="absolute top-1/2 -translate-y-1/2 w-20 h-11 bg-[#323038] rounded-md border border-white/20 shadow-[0_12px_24px_rgba(0,0,0,0.7),inset_0_1px_1px_rgba(255,255,255,0.1)] flex items-center justify-center transition-all duration-150 z-10 group-hover:border-[#D0BCFF]/40 active:scale-95 active:shadow-inner"
+             className="absolute top-1/2 -translate-y-1/2 w-24 h-12 bg-[#323038] rounded-md border border-white/20 shadow-[0_12px_24px_rgba(0,0,0,0.7),inset_0_1px_1px_rgba(255,255,255,0.1)] flex items-center justify-center transition-all duration-150 z-10 group-hover:border-[#D0BCFF]/40 active:scale-95 active:shadow-inner"
              style={{ 
-               left: `calc(1rem + ${(crossfader + 1) / 2} * (100% - 2rem - 5rem))`,
+               left: `calc(1rem + ${(crossfader + 1) / 2} * (100% - 2rem - 6rem))`,
              }}
            >
              {/* Tactile Handle Ridges */}
@@ -373,7 +373,7 @@ const Mixer: React.FC<MixerProps> = ({
              </div>
              
              {/* Visual percentage badge (appears on hover) */}
-             <div className="absolute -top-10 left-1/2 -translate-x-1/2 bg-[#D0BCFF] text-black text-[9px] font-black px-2.5 py-1 rounded-full opacity-0 group-hover:opacity-100 transition-all transform group-hover:-translate-y-1 pointer-events-none shadow-2xl border border-white/20 uppercase tracking-tighter whitespace-nowrap">
+             <div className="absolute -top-12 left-1/2 -translate-x-1/2 bg-[#D0BCFF] text-black text-xs font-black px-3 py-1 rounded-full opacity-0 group-hover:opacity-100 transition-all transform group-hover:-translate-y-1 pointer-events-none shadow-2xl border border-white/20 uppercase tracking-tighter whitespace-nowrap">
                {Math.abs(crossfader) < 0.01 ? '50% Center' : `${Math.round(((crossfader + 1) / 2) * 100)}%`}
              </div>
            </div>
@@ -392,12 +392,12 @@ const Mixer: React.FC<MixerProps> = ({
 
         {/* Labels below the fader as seen in screenshots */}
         <div className="flex justify-between items-center px-1 mt-1 font-black uppercase tracking-[0.25em]">
-           <span className={`text-[7px] transition-colors ${crossfader < -0.8 ? 'text-[#D0BCFF]' : 'text-gray-600'}`}>Deck A</span>
+           <span className={`text-[10px] transition-colors ${crossfader < -0.8 ? 'text-[#D0BCFF]' : 'text-gray-400'}`}>Deck A</span>
            <div className="flex flex-col items-center">
-             <span className={`text-[9px] font-mono transition-all duration-200 ${Math.abs(crossfader) < 0.05 ? 'text-white scale-125 glow-white' : 'text-gray-700'}`}>0</span>
+             <span className={`text-xs font-mono transition-all duration-200 ${Math.abs(crossfader) < 0.05 ? 'text-white scale-125 glow-white' : 'text-gray-400'}`}>0</span>
              <div className={`w-1 h-1 rounded-full transition-colors ${Math.abs(crossfader) < 0.05 ? 'bg-white shadow-[0_0_5px_white]' : 'bg-transparent'}`} />
            </div>
-           <span className={`text-[7px] transition-colors ${crossfader > 0.8 ? 'text-[#F2B8B5]' : 'text-gray-600'}`}>Deck B</span>
+           <span className={`text-[10px] transition-colors ${crossfader > 0.8 ? 'text-[#F2B8B5]' : 'text-gray-400'}`}>Deck B</span>
         </div>
       </div>
     </div>

--- a/raikomix-youtube-dj_1.0/components/layouts/MobileLandscapeLayout.tsx
+++ b/raikomix-youtube-dj_1.0/components/layouts/MobileLandscapeLayout.tsx
@@ -43,7 +43,7 @@ const MobileLandscapeLayout: React.FC<MobileLandscapeLayoutProps> = ({
           <button
             type="button"
             onClick={() => onSheetToggle(!sheetOpen)}
-            className="panel-trigger touch-target"
+            className="panel-trigger m3-touch touch-target"
             aria-expanded={sheetOpen}
           >
             <span className="material-icons text-base">queue_music</span>
@@ -52,7 +52,7 @@ const MobileLandscapeLayout: React.FC<MobileLandscapeLayoutProps> = ({
           <button
             type="button"
             onClick={() => onEffectsToggle(!effectsOpen)}
-            className="panel-trigger touch-target"
+            className="panel-trigger m3-touch touch-target"
             aria-expanded={effectsOpen}
           >
             <span className="material-icons text-base">tune</span>
@@ -77,7 +77,7 @@ const MobileLandscapeLayout: React.FC<MobileLandscapeLayoutProps> = ({
                   key={tab}
                   type="button"
                   onClick={() => onSheetTabChange(tab)}
-                  className={`panel-tab touch-target ${sheetTab === tab ? 'is-active' : ''}`}
+                  className={`panel-tab m3-touch touch-target ${sheetTab === tab ? 'is-active' : ''}`}
                   aria-pressed={sheetTab === tab}
                 >
                   {tab === 'LIBRARY' ? 'Library' : 'Queue'}
@@ -88,7 +88,7 @@ const MobileLandscapeLayout: React.FC<MobileLandscapeLayoutProps> = ({
               <button
                 type="button"
                 onClick={onSheetExpandedToggle}
-                className="utility-button touch-target"
+                className="utility-button m3-touch touch-target"
                 aria-label={sheetExpanded ? 'Collapse panel' : 'Expand panel'}
               >
                 <span className="material-icons text-base">{sheetExpanded ? 'expand_more' : 'expand_less'}</span>
@@ -96,7 +96,7 @@ const MobileLandscapeLayout: React.FC<MobileLandscapeLayoutProps> = ({
               <button
                 type="button"
                 onClick={() => onSheetToggle(false)}
-                className="utility-button touch-target"
+                className="utility-button m3-touch touch-target"
                 aria-label="Close panel"
               >
                 <span className="material-icons text-base">close</span>
@@ -120,7 +120,7 @@ const MobileLandscapeLayout: React.FC<MobileLandscapeLayoutProps> = ({
           <button
             type="button"
             onClick={() => onEffectsToggle(false)}
-            className="utility-button touch-target"
+            className="utility-button m3-touch touch-target"
             aria-label="Close effects"
           >
             <span className="material-icons text-base">close</span>

--- a/raikomix-youtube-dj_1.0/components/layouts/MobilePortraitLayout.tsx
+++ b/raikomix-youtube-dj_1.0/components/layouts/MobilePortraitLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useRef } from 'react';
 
 export type MobilePanelTab = 'LIBRARY' | 'QUEUE' | 'EFFECTS';
 
@@ -8,6 +8,8 @@ interface MobilePortraitLayoutProps {
   mixer: ReactNode;
   deckFocus: 'A' | 'B';
   onDeckFocusChange: (deck: 'A' | 'B') => void;
+  navTab: 'LIBRARY' | 'DECK_A' | 'DECK_B' | 'MIXER';
+  onNavTabChange: (tab: 'LIBRARY' | 'DECK_A' | 'DECK_B' | 'MIXER') => void;
   sheetOpen: boolean;
   sheetTab: MobilePanelTab;
   onSheetTabChange: (tab: MobilePanelTab) => void;
@@ -18,6 +20,7 @@ interface MobilePortraitLayoutProps {
   queuePanel: ReactNode;
   effectsPanel: ReactNode;
   utilityBar?: ReactNode;
+  compactMixer?: ReactNode;
 }
 
 const MobilePortraitLayout: React.FC<MobilePortraitLayoutProps> = ({
@@ -26,6 +29,8 @@ const MobilePortraitLayout: React.FC<MobilePortraitLayoutProps> = ({
   mixer,
   deckFocus,
   onDeckFocusChange,
+  navTab,
+  onNavTabChange,
   sheetOpen,
   sheetTab,
   onSheetTabChange,
@@ -35,70 +40,109 @@ const MobilePortraitLayout: React.FC<MobilePortraitLayoutProps> = ({
   libraryPanel,
   queuePanel,
   effectsPanel,
-  utilityBar
+  utilityBar,
+  compactMixer
 }) => {
+  const swipeStartX = useRef<number | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    swipeStartX.current = event.clientX;
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (swipeStartX.current === null) return;
+    const deltaX = event.clientX - swipeStartX.current;
+    if (Math.abs(deltaX) > 60) {
+      const nextDeck = deltaX < 0 ? 'B' : 'A';
+      onDeckFocusChange(nextDeck);
+      onNavTabChange(nextDeck === 'A' ? 'DECK_A' : 'DECK_B');
+    }
+    swipeStartX.current = null;
+  };
+
   return (
     <div className="mobile-layout" id="main-content">
-      {/* Mobile portrait: top deck switcher, active deck stack, mixer strip, bottom sheet tabs. */}
-      <header className="mobile-header">
-        <div className="deck-switcher" role="tablist" aria-label="Deck switcher">
-          <button
-            type="button"
-            onClick={() => onDeckFocusChange('A')}
-            className={`deck-switcher__button touch-target ${deckFocus === 'A' ? 'is-active' : ''}`}
-            aria-pressed={deckFocus === 'A'}
-          >
-            Deck A
-          </button>
-          <button
-            type="button"
-            onClick={() => onDeckFocusChange('B')}
-            className={`deck-switcher__button deck-switcher__button--b touch-target ${deckFocus === 'B' ? 'is-active' : ''}`}
-            aria-pressed={deckFocus === 'B'}
-          >
-            Deck B
-          </button>
+      <header className="mobile-top-bar">
+        <div>
+          <p className="text-xs font-semibold text-[var(--md-sys-color-on-surface-variant)] uppercase tracking-[0.3em]">
+            RaikoMix
+          </p>
+          <p className="text-base font-semibold">Mobile DJ Console</p>
         </div>
-        <div className="mobile-actions">
-          <button
-            type="button"
-            onClick={() => onSheetToggle(!sheetOpen)}
-            className="panel-trigger touch-target"
-            aria-expanded={sheetOpen}
-          >
-            <span className="material-icons text-base">library_music</span>
-            Panels
-          </button>
-          {utilityBar}
-        </div>
+        <div className="utility-bar">{utilityBar}</div>
       </header>
 
-      <div className="deck-stack">
-        <div className={`deck-slot ${deckFocus === 'A' ? '' : 'is-hidden'}`} aria-hidden={deckFocus !== 'A'}>
-          {deckA}
-        </div>
-        <div className={`deck-slot ${deckFocus === 'B' ? '' : 'is-hidden'}`} aria-hidden={deckFocus !== 'B'}>
-          {deckB}
-        </div>
+      <div className="mobile-main">
+        {(navTab === 'DECK_A' || navTab === 'DECK_B' || navTab === 'LIBRARY') && (
+          <>
+            <div className="deck-tabs" role="tablist" aria-label="Deck switcher">
+              <button
+                type="button"
+                onClick={() => {
+                  onDeckFocusChange('A');
+                  onNavTabChange('DECK_A');
+                }}
+                className={`deck-tab m3-touch touch-target ${deckFocus === 'A' ? 'is-active' : ''}`}
+                aria-pressed={deckFocus === 'A'}
+              >
+                Deck A
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  onDeckFocusChange('B');
+                  onNavTabChange('DECK_B');
+                }}
+                className={`deck-tab m3-touch touch-target ${deckFocus === 'B' ? 'is-active' : ''}`}
+                aria-pressed={deckFocus === 'B'}
+              >
+                Deck B
+              </button>
+            </div>
+
+            <div
+              className="deck-stack"
+              onPointerDown={handlePointerDown}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerUp}
+            >
+              <div className={`deck-slot ${deckFocus === 'A' ? '' : 'is-hidden'}`} aria-hidden={deckFocus !== 'A'}>
+                {deckA}
+              </div>
+              <div className={`deck-slot ${deckFocus === 'B' ? '' : 'is-hidden'}`} aria-hidden={deckFocus !== 'B'}>
+                {deckB}
+              </div>
+            </div>
+          </>
+        )}
+
+        {navTab === 'MIXER' && (
+          <section className="space-y-3" aria-label="Mixer">
+            {mixer}
+            <details className="collapsible-panel">
+              <summary>Effects</summary>
+              <div className="collapsible-content">{effectsPanel}</div>
+            </details>
+          </section>
+        )}
       </div>
 
-      <section className="mixer-strip" aria-label="Mixer">
-        {mixer}
-      </section>
-
       {sheetOpen && (
-        <div className="panel-sheet elevation-4" data-expanded={sheetExpanded} role="dialog" aria-label="Performance panels">
+        <div className="panel-sheet elevation-4" data-expanded={sheetExpanded} role="dialog" aria-label="Library and queue">
+          <div className="flex justify-center pt-3">
+            <div className="panel-sheet__handle" aria-hidden="true" />
+          </div>
           <div className="panel-sheet__header">
             <div className="panel-sheet__tabs">
-              {(['LIBRARY', 'QUEUE', 'EFFECTS'] as const).map((tab) => (
+              {(['LIBRARY', 'QUEUE'] as const).map((tab) => (
                 <button
                   key={tab}
                   type="button"
                   onClick={() => onSheetTabChange(tab)}
-                  className={`panel-tab touch-target ${sheetTab === tab ? 'is-active' : ''}`}
+                  className={`panel-tab m3-touch touch-target ${sheetTab === tab ? 'is-active' : ''}`}
                   aria-pressed={sheetTab === tab}
                 >
-                  {tab === 'LIBRARY' ? 'Library' : tab === 'QUEUE' ? 'Queue' : 'Effects'}
+                  {tab === 'LIBRARY' ? 'Library' : 'Queue'}
                 </button>
               ))}
             </div>
@@ -106,7 +150,7 @@ const MobilePortraitLayout: React.FC<MobilePortraitLayoutProps> = ({
               <button
                 type="button"
                 onClick={onSheetExpandedToggle}
-                className="utility-button touch-target"
+                className="utility-button m3-touch touch-target"
                 aria-label={sheetExpanded ? 'Collapse panel' : 'Expand panel'}
               >
                 <span className="material-icons text-base">{sheetExpanded ? 'expand_more' : 'expand_less'}</span>
@@ -114,7 +158,7 @@ const MobilePortraitLayout: React.FC<MobilePortraitLayoutProps> = ({
               <button
                 type="button"
                 onClick={() => onSheetToggle(false)}
-                className="utility-button touch-target"
+                className="utility-button m3-touch touch-target"
                 aria-label="Close panel"
               >
                 <span className="material-icons text-base">close</span>
@@ -128,12 +172,31 @@ const MobilePortraitLayout: React.FC<MobilePortraitLayoutProps> = ({
             <div className={`panel-sheet__panel ${sheetTab === 'QUEUE' ? '' : 'is-hidden'}`}>
               {queuePanel}
             </div>
-            <div className={`panel-sheet__panel ${sheetTab === 'EFFECTS' ? '' : 'is-hidden'}`}>
-              {effectsPanel}
-            </div>
           </div>
         </div>
       )}
+
+      {compactMixer && <div className="mobile-mixer-bar">{compactMixer}</div>}
+
+      <nav className="mobile-bottom-nav" aria-label="Primary">
+        {([
+          { id: 'LIBRARY', label: 'Library', icon: 'library_music' },
+          { id: 'DECK_A', label: 'Deck A', icon: 'album' },
+          { id: 'DECK_B', label: 'Deck B', icon: 'graphic_eq' },
+          { id: 'MIXER', label: 'Mixer', icon: 'tune' }
+        ] as const).map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => onNavTabChange(item.id)}
+            className={`bottom-nav__item m3-touch touch-target ${navTab === item.id ? 'is-active' : ''}`}
+            aria-pressed={navTab === item.id}
+          >
+            <span className="material-icons bottom-nav__icon">{item.icon}</span>
+            {item.label}
+          </button>
+        ))}
+      </nav>
     </div>
   );
 };

--- a/raikomix-youtube-dj_1.0/components/layouts/TabletLayout.tsx
+++ b/raikomix-youtube-dj_1.0/components/layouts/TabletLayout.tsx
@@ -39,7 +39,7 @@ const TabletLayout: React.FC<TabletLayoutProps> = ({
                   key={tab}
                   type="button"
                   onClick={() => onPanelTabChange(tab)}
-                  className={`panel-tab touch-target ${panelTab === tab ? 'is-active' : ''}`}
+                  className={`panel-tab m3-touch touch-target ${panelTab === tab ? 'is-active' : ''}`}
                   aria-pressed={panelTab === tab}
                 >
                   {tab === 'LIBRARY' ? 'Library' : 'Queue'}
@@ -75,7 +75,7 @@ const TabletLayout: React.FC<TabletLayoutProps> = ({
             <button
               type="button"
               onClick={onEffectsCollapseToggle}
-              className="utility-button touch-target"
+              className="utility-button m3-touch touch-target"
               aria-label={effectsCollapsed ? 'Expand effects' : 'Collapse effects'}
             >
               <span className="material-icons text-base">{effectsCollapsed ? 'chevron_left' : 'chevron_right'}</span>

--- a/raikomix-youtube-dj_1.0/index.html
+++ b/raikomix-youtube-dj_1.0/index.html
@@ -37,17 +37,17 @@
     }
     input[type=range]::-webkit-slider-runnable-track {
       width: 100%;
-      height: 4px;
+      height: 6px;
       background: var(--md-sys-color-surface-variant);
-      border-radius: 2px;
+      border-radius: 999px;
     }
     input[type=range]::-webkit-slider-thumb {
       -webkit-appearance: none;
-      height: 20px;
-      width: 20px;
+      height: 24px;
+      width: 24px;
       border-radius: 50%;
       background: var(--md-sys-color-primary);
-      margin-top: -8px;
+      margin-top: -9px;
       box-shadow: var(--md-sys-elevation-1);
       cursor: pointer;
     }

--- a/raikomix-youtube-dj_1.0/styles/layout.css
+++ b/raikomix-youtube-dj_1.0/styles/layout.css
@@ -25,8 +25,44 @@
 }
 
 .touch-target {
-  min-height: 44px;
-  min-width: 44px;
+  min-height: 48px;
+  min-width: 48px;
+}
+
+.m3-touch {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.m3-touch::after,
+button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: currentColor;
+  opacity: 0;
+  transition: opacity 140ms ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.m3-touch:active::after,
+.m3-touch:focus-visible::after,
+button:active::after,
+button:focus-visible::after {
+  opacity: 0.12;
+}
+
+button {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+button > * {
+  position: relative;
+  z-index: 1;
 }
 
 .mobile-layout {
@@ -35,7 +71,30 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 12px;
+  padding: 16px 16px 0;
+  background: var(--md-sys-color-surface);
+}
+
+.mobile-top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 16px;
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--md-sys-elevation-1);
+}
+
+.mobile-main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: auto;
+  padding-bottom: calc(168px + env(safe-area-inset-bottom));
 }
 
 .mobile-header {
@@ -53,6 +112,34 @@
   display: inline-flex;
   gap: 8px;
   align-items: center;
+}
+
+.deck-tabs {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  background: var(--md-sys-color-surface-container-high);
+  padding: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.deck-tab {
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.deck-tab.is-active {
+  background: var(--md-sys-color-primary);
+  color: var(--md-sys-color-on-primary);
+  box-shadow: 0 0 14px rgba(208, 188, 255, 0.35);
 }
 
 .deck-switcher__button {
@@ -106,6 +193,7 @@
   flex: 1;
   min-height: 0;
   display: grid;
+  gap: 12px;
 }
 
 .deck-slot {
@@ -120,6 +208,59 @@
   display: flex;
   justify-content: center;
   align-items: stretch;
+}
+
+.mobile-mixer-bar {
+  position: fixed;
+  left: 16px;
+  right: 16px;
+  bottom: calc(72px + env(safe-area-inset-bottom));
+  padding: 12px;
+  border-radius: 20px;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--md-sys-elevation-2);
+  z-index: 45;
+}
+
+.mobile-bottom-nav {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 8px 16px calc(12px + env(safe-area-inset-bottom));
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  background: var(--md-sys-color-surface-container);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--md-sys-elevation-2);
+  z-index: 50;
+}
+
+.bottom-nav__item {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px;
+  border-radius: 16px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface-variant);
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+.bottom-nav__item.is-active {
+  background: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-on-primary-container);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.bottom-nav__icon {
+  font-size: 20px;
 }
 
 .landscape-grid {
@@ -143,7 +284,7 @@
   position: fixed;
   left: 12px;
   right: 12px;
-  bottom: calc(16px + env(safe-area-inset-bottom));
+  bottom: calc(96px + env(safe-area-inset-bottom));
   margin: 0 auto;
   max-width: 960px;
   background: var(--md-sys-color-surface-container);
@@ -154,6 +295,7 @@
   height: var(--sheet-collapsed);
   transition: height var(--md-sys-motion-duration-medium4) var(--md-sys-motion-easing-emphasized);
   z-index: 40;
+  box-shadow: var(--md-sys-elevation-4);
 }
 
 .panel-sheet[data-expanded='true'] {
@@ -168,6 +310,13 @@
   padding: 12px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(0, 0, 0, 0.35);
+}
+
+.panel-sheet__handle {
+  width: 40px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .panel-sheet__tabs {
@@ -197,6 +346,55 @@
 .panel-sheet__actions {
   display: inline-flex;
   gap: 6px;
+}
+
+.collapsible-panel {
+  border-radius: 16px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 12px;
+}
+
+.collapsible-panel summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.collapsible-panel summary::-webkit-details-marker {
+  display: none;
+}
+
+.collapsible-panel summary::after {
+  content: 'expand_more';
+  font-family: 'Material Icons';
+  font-size: 18px;
+  color: var(--md-sys-color-on-surface-variant);
+  transition: transform 150ms ease;
+}
+
+.collapsible-panel[open] summary::after {
+  transform: rotate(180deg);
+}
+
+.collapsible-content {
+  margin-top: 12px;
+}
+
+.collapsible-panel:not([open]) > .collapsible-content {
+  display: none;
+}
+
+.m3-section-title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--md-sys-color-on-surface-variant);
 }
 
 .panel-sheet__body {
@@ -299,8 +497,8 @@
 }
 
 .utility-button {
-  width: 44px;
-  height: 44px;
+  width: 48px;
+  height: 48px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(0, 0, 0, 0.4);
@@ -314,6 +512,10 @@
   .tablet-layout {
     display: none;
   }
+  button {
+    min-height: 48px;
+    min-width: 48px;
+  }
 }
 
 @media (max-width: 567px) {
@@ -322,18 +524,28 @@
     right: 8px;
   }
   .mobile-layout {
-    padding: 10px;
+    padding: 12px 12px 0;
   }
 }
 
 @media (max-width: 567px) {
   .app-shell {
-    font-size: 14px;
+    font-size: 16px;
   }
 }
 
 @media (min-width: 568px) and (max-width: 767px) {
   .app-shell {
-    font-size: 15px;
+    font-size: 16px;
+  }
+}
+
+@media (min-width: 768px) {
+  .collapsible-panel summary {
+    display: none;
+  }
+  .collapsible-panel > .collapsible-content {
+    display: block;
+    margin-top: 0;
   }
 }


### PR DESCRIPTION
### Motivation
- Convert the desktop-first, dense UI into a mobile-first experience that follows Material Design 3 touch and spacing guidelines. 
- Improve usability on phones by enlarging touch targets, simplifying navigation, and reducing information density with progressive disclosure. 
- Preserve core DJ features (dual decks, BPM, crossfader, EQ, FX, cues, YouTube library/queue) while making controls accessible for touch.

### Description
- Implemented a mobile-first portrait layout with bottom navigation (Library, Deck A, Deck B, Mixer), a compact mixer footer, and swipe-to-switch decks via a new `mobileNavTab` state in `App.tsx` and a redesigned `MobilePortraitLayout` (adds `compactMixer`, bottom nav, sheet handle, collapsible panels). 
- Added `CompactMixer` component and wired it into the mobile layout; updated `App.tsx` to manage mobile nav state and sheet behavior for a consistent bottom-sheet experience. 
- Increased touch target sizes and Material You state layers: updated `styles/layout.css` (touch targets to 48px, `m3-touch` ripple/state helpers, bottom nav, mobile mixer bar, panel sheet styling, collapsible panels) and `index.html` slider/thumb sizes for larger hit areas. 
- Enlarged and reflowed UI elements for touch: updated `Deck.tsx`, `Mixer.tsx`, and `EffectsPanel.tsx` to use larger knobs/faders/buttons, improved typography and spacing, added collapsible performance sections and larger interactive controls, and applied `m3-touch`/`touch-target` classes across layouts. 

### Testing
- Launched the dev server with `npm run dev` and confirmed Vite started and served the app; this succeeded. 
- Ran an automated Playwright script that loaded the app at a mobile viewport (390x844) and captured a screenshot (`artifacts/mobile-ux.png`), which completed successfully. 
- No unit or E2E test suites were run beyond the dev server + Playwright screenshot (no failures observed during these runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c1f4043e08326bdcd4b4b2608d357)